### PR TITLE
Fix `corfu--teardown` signature (backward compatible)

### DIFF
--- a/modes/corfu/evil-collection-corfu.el
+++ b/modes/corfu/evil-collection-corfu.el
@@ -127,7 +127,7 @@ This key theme variable may be refactored in the future so use with caution."
       (kbd "C-d") 'corfu-scroll-down))
 
   (advice-add 'corfu--setup :after (lambda (&rest _) (evil-normalize-keymaps)))
-  (advice-add 'corfu--teardown :after 'evil-normalize-keymaps))
+  (advice-add 'corfu--teardown :after (lambda (&rest _) (evil-normalize-keymaps))))
 
 (provide 'evil-collection-corfu)
 ;;; evil-collection-corfu.el ends here


### PR DESCRIPTION
A new commit in `corfu` changes the signature of `corfu--teardown`, this PR fixes that.

## References
- https://github.com/minad/corfu/commit/61a20a50369de2cae77d649269d3c047fbbc27ec
- https://github.com/emacs-evil/evil-collection/pull/767#issuecomment-1875366132
